### PR TITLE
Fix for h264 video dimensions calculation

### DIFF
--- a/codec/h264parser/parser_test.go
+++ b/codec/h264parser/parser_test.go
@@ -2,12 +2,12 @@ package h264parser
 
 import (
 	"encoding/hex"
-	"testing"
 	"github.com/stretchr/testify/assert"
 	"io/ioutil"
+	"os"
 	"path"
 	"runtime"
-	"os"
+	"testing"
 )
 
 func addToCorpus(data []byte, name string) {
@@ -50,6 +50,20 @@ func TestParserNoCrash(t *testing.T) {
 	assert.Equal(t, NALU_AVCC, typ)
 }
 
+func TestParserSpsParse(t *testing.T) {
+	spsFrame, err := hex.DecodeString(
+		"674d4033f30140c7e7c044000003000400000300c87c58b9a0",
+	)
 
+	info, err := ParseSPS(spsFrame)
 
-
+	assert.NoError(t, err)
+	assert.Equal(t, info.SubHeightC, uint(2))
+	assert.Equal(t, info.SubWidthC, uint(2))
+	assert.Equal(t, info.CropTop, uint(0))
+	assert.Equal(t, info.CropRight, uint(0))
+	assert.Equal(t, info.CropLeft, uint(0))
+	assert.Equal(t, info.CropBottom, uint(6))
+	assert.Equal(t, info.Width, uint(640))
+	assert.Equal(t, info.Height, uint(360))
+}


### PR DESCRIPTION
CropUnit used for width and height calculations is not fixed
and could be changed for different values of chroma_format_idc in SPS
Additionally CropUnitY is dependent of SPS.frame_mbs_only_flag
Previously CropUnitY was applied only to MbHeight, but not to CropTop or CropBottop,
PicHeight calced wrong for cropped pictures.